### PR TITLE
Add AddRechargeToAll helper for global ability cooldowns

### DIFF
--- a/lambdawars/python/core/abilities/base.py
+++ b/lambdawars/python/core/abilities/base.py
@@ -383,6 +383,48 @@ class AbilityBase(AbilityInfo):
             for unit in units:
                 for uid in abi_uids:
                     unit.abilitynexttime[uid] = gpGlobals.curtime + self.rechargetime + t
+                if not hasattr(unit, '_recharge_all'):
+                    unit._recharge_all = set()
+                unit._recharge_all.add(self.uid)
+
+    @serveronly_assert
+    def AddRechargeToAll(cls, ability_names, t=0, owner_number=None):
+        """Tracks abilities already processed by SetRecharge during this update,
+           preventing AddRechargeToAll from applying the cooldown twice."""
+        if owner_number is None and hasattr(cls, 'ownernumber'):
+            owner_number = cls.ownernumber
+
+        if isinstance(ability_names, str):
+            ability_names = [ability_names]
+        
+        # TODO: Maybe can do this better?
+        from core.units.info import unitlist
+
+        uid_set = set()
+        for name in ability_names:
+            abi = GetAbilityInfo(name)
+            if not abi:
+                continue
+            uid_set.add(abi.uid)
+
+        for units in unitlist.values():
+            for unit in units:
+                if not unit:
+                    continue
+
+                if owner_number is not None and unit.GetOwnerNumber() != owner_number:
+                    continue
+
+                for uid in uid_set:
+                    if hasattr(unit, '_recharge_all') and uid in unit._recharge_all:
+                        continue
+
+                    current = unit.abilitynexttime.get(uid, gpGlobals.curtime)
+                    base = max(current, gpGlobals.curtime)
+                    unit.abilitynexttime[uid] = base + t
+
+                if hasattr(unit, '_recharge_all'):
+                    unit._recharge_all.clear()
                 
     @serveronly_assert
     def Refund(self):

--- a/lambdawars/python/wars_game/abilities/combineball.py
+++ b/lambdawars/python/wars_game/abilities/combineball.py
@@ -28,13 +28,16 @@ if isserver:
 
     class ActionShootCombineBall(BehaviorGeneric.ActionMoveInRangeAndFace):
         def Init(self, order, parent_action):
-            target = order.target if order.target else order.position
-            
-            super().Init(target, 1024.0)
+            target = order.target
 
+			# Ignore combine balls.
+			if not target or FClassnameIs(target, "prop_combine_ball"):
+			    target = order.position
+
+			super().Init(target, 1024.0)
             self.parent_action = parent_action
             self.ability = order.ability
-            
+
         def Update(self):
             ability = self.ability
             if not self.target:

--- a/lambdawars/python/wars_game/abilities/powers/headcrabcanister.py
+++ b/lambdawars/python/wars_game/abilities/powers/headcrabcanister.py
@@ -124,6 +124,7 @@ class AbilityCanister(AbilityTarget):
                 self.Cancel(cancelmsg='#Ability_InvalidPosition', debugmsg='must be fired within range')
                 return
             self.SetRecharge(self.unit)
+            self.AddRechargeToAll(["launch_headcrabcanister", "launch_headcrabcanister_fasttype", "launch_headcrabcanister_poisontype", "launch_headcrabcanister_emptytype"], t=1.0)
             self.Completed()
         
     def UpdateParticleEffects(self, inst, targetpos):

--- a/lambdawars/python/wars_game/units/basezombie.py
+++ b/lambdawars/python/wars_game/units/basezombie.py
@@ -96,8 +96,10 @@ class UnitBaseZombie(BaseClass):
         #
         vecMins = self.WorldAlignMins()
         vecMaxs = self.WorldAlignMaxs()
-        vecMins.z = vecMins.x
-        vecMaxs.z = vecMaxs.x
+        # Using the Z axis here gives more reliable melee traces than using the X axis.
+        # This fixes issues with hitting small units (manhacks, headcrabs) and enemies standing on ledges.
+        vecMins.z = -24
+        vecMaxs.z = 24
 
         '''
         pHurt = None

--- a/lambdawars/python/wars_game/units/combine.py
+++ b/lambdawars/python/wars_game/units/combine.py
@@ -315,6 +315,29 @@ class UnitCombineHeavy(UnitCombine):
             super().Precache()
             
             self.PrecacheScriptSound( "combine_heavy_shield" )
+
+        class CombineHeavyThrowGrenade(UnitCombine.CombineThrowGrenade):
+            def HandleEvent(self, unit, event):
+                abi = unit.grenadeability
+                if not abi:
+                    return
+
+                if abi.grenadeclsname:
+                    self.SetGrenadeClass(abi.grenadeclsname)
+
+                startpos = Vector()
+                unit.GetAttachment("anim_attachment_RH", startpos)
+                targetpos = abi.throwtarget.GetAbsOrigin() if abi.throwtarget else abi.throwtargetpos
+
+                grenade = self.TossGrenade(unit, startpos, targetpos, unit.CalculateIgnoreOwnerCollisionGroup())
+
+                if grenade:
+                    abi.OnGrenadeThrowed(unit, grenade)
+                    grenade.SetVelocity(grenade.GetAbsVelocity(), Vector(0, 0, 0))
+                    grenade.SetTimer(2.5, 2.5 - grenade.FRAG_GRENADE_WARN_TIME)
+                    
+        aetable = dict(UnitCombine.aetable)
+        aetable[UnitCombine.COMBINE_AE_GREN_TOSS] = CombineHeavyThrowGrenade('grenade_frag', UnitCombine.COMBINE_GRENADE_THROW_SPEED)
             
 # Register unit
 class CombineSharedInfo(UnitInfo):

--- a/lambdawars/python/wars_game/units/headcrab.py
+++ b/lambdawars/python/wars_game/units/headcrab.py
@@ -333,6 +333,11 @@ class UnitBaseHeadcrab(BaseClass):
                 if enemy and unit.controllerplayer is None:
                     if unit.committedtojump:
                         unit.JumpAttack(False, unit.veccommittedjumppos)
+                    elif getattr(enemy, 'hd_jump_target_worldcenter', False):
+                        # Intended for entities where EyePosition() is unsuitable
+                        # (e.g. synthfactory, mortarsynth, teleporter,
+                        # control points, barricades, mountableturrets).
+                        unit.JumpAttack(False, enemy.WorldSpaceCenter())
                     else:
                         # Jump at my enemy's eyes.
                         unit.JumpAttack(False, enemy.EyePosition())


### PR DESCRIPTION
This PR includes several gameplay improvements:

- Added a new helper method `AddRechargeToAll` to apply additional cooldowns to abilities across all units while preventing duplicate cooldown application when `SetRecharge` has already processed the same ability.
- Fixed headcrab jump targeting for low-profile entities by allowing specific entities to use `WorldSpaceCenter()` as the jump target.
- Improved zombie melee hit detection against small units and targets on elevation changes.
- Fixed Combine Heavy grenade spawning to ensure the projectile is created from the correct attachment point.
- Fixed Combine Ball target selection so it no longer attempts to target other Combine Balls.

P.S. The headcrab jump targeting improvement requires entities to explicitly opt in by defining the `hd_jump_target_worldcenter` flag. Existing entities will continue using `EyePosition()` unless this flag is added.