### PR TITLE
Overrun upgrades fix

### DIFF
--- a/lambdawars/python/core/abilities/base.py
+++ b/lambdawars/python/core/abilities/base.py
@@ -383,6 +383,48 @@ class AbilityBase(AbilityInfo):
             for unit in units:
                 for uid in abi_uids:
                     unit.abilitynexttime[uid] = gpGlobals.curtime + self.rechargetime + t
+                if not hasattr(unit, '_recharge_all'):
+                    unit._recharge_all = set()
+                unit._recharge_all.add(self.uid)
+
+    @serveronly_assert
+    def AddRechargeToAll(cls, ability_names, t=0, owner_number=None):
+        """Tracks abilities already processed by SetRecharge during this update,
+           preventing AddRechargeToAll from applying the cooldown twice."""
+        if owner_number is None and hasattr(cls, 'ownernumber'):
+            owner_number = cls.ownernumber
+
+        if isinstance(ability_names, str):
+            ability_names = [ability_names]
+        
+        # TODO: Maybe can do this better?
+        from core.units.info import unitlist
+
+        uid_set = set()
+        for name in ability_names:
+            abi = GetAbilityInfo(name)
+            if not abi:
+                continue
+            uid_set.add(abi.uid)
+
+        for units in unitlist.values():
+            for unit in units:
+                if not unit:
+                    continue
+
+                if owner_number is not None and unit.GetOwnerNumber() != owner_number:
+                    continue
+
+                for uid in uid_set:
+                    if hasattr(unit, '_recharge_all') and uid in unit._recharge_all:
+                        continue
+
+                    current = unit.abilitynexttime.get(uid, gpGlobals.curtime)
+                    base = max(current, gpGlobals.curtime)
+                    unit.abilitynexttime[uid] = base + t
+
+                if hasattr(unit, '_recharge_all'):
+                    unit._recharge_all.clear()
                 
     @serveronly_assert
     def Refund(self):

--- a/lambdawars/python/wars_game/abilities/combineball.py
+++ b/lambdawars/python/wars_game/abilities/combineball.py
@@ -28,13 +28,16 @@ if isserver:
 
     class ActionShootCombineBall(BehaviorGeneric.ActionMoveInRangeAndFace):
         def Init(self, order, parent_action):
-            target = order.target if order.target else order.position
-            
-            super().Init(target, 1024.0)
+            target = order.target
 
+			# Ignore combine balls.
+			if not target or FClassnameIs(target, "prop_combine_ball"):
+			    target = order.position
+
+			super().Init(target, 1024.0)
             self.parent_action = parent_action
             self.ability = order.ability
-            
+
         def Update(self):
             ability = self.ability
             if not self.target:

--- a/lambdawars/python/wars_game/abilities/powers/headcrabcanister.py
+++ b/lambdawars/python/wars_game/abilities/powers/headcrabcanister.py
@@ -124,6 +124,7 @@ class AbilityCanister(AbilityTarget):
                 self.Cancel(cancelmsg='#Ability_InvalidPosition', debugmsg='must be fired within range')
                 return
             self.SetRecharge(self.unit)
+            self.AddRechargeToAll(["launch_headcrabcanister", "launch_headcrabcanister_fasttype", "launch_headcrabcanister_poisontype", "launch_headcrabcanister_emptytype"], t=1.0)
             self.Completed()
         
     def UpdateParticleEffects(self, inst, targetpos):

--- a/lambdawars/python/wars_game/units/basezombie.py
+++ b/lambdawars/python/wars_game/units/basezombie.py
@@ -96,8 +96,10 @@ class UnitBaseZombie(BaseClass):
         #
         vecMins = self.WorldAlignMins()
         vecMaxs = self.WorldAlignMaxs()
-        vecMins.z = vecMins.x
-        vecMaxs.z = vecMaxs.x
+        # Using the Z axis here gives more reliable melee traces than using the X axis.
+        # This fixes issues with hitting small units (manhacks, headcrabs) and enemies standing on ledges.
+        vecMins.z = -24
+        vecMaxs.z = 24
 
         '''
         pHurt = None

--- a/lambdawars/python/wars_game/units/combine.py
+++ b/lambdawars/python/wars_game/units/combine.py
@@ -315,6 +315,29 @@ class UnitCombineHeavy(UnitCombine):
             super().Precache()
             
             self.PrecacheScriptSound( "combine_heavy_shield" )
+
+        class CombineHeavyThrowGrenade(UnitCombine.CombineThrowGrenade):
+            def HandleEvent(self, unit, event):
+                abi = unit.grenadeability
+                if not abi:
+                    return
+
+                if abi.grenadeclsname:
+                    self.SetGrenadeClass(abi.grenadeclsname)
+
+                startpos = Vector()
+                unit.GetAttachment("anim_attachment_RH", startpos)
+                targetpos = abi.throwtarget.GetAbsOrigin() if abi.throwtarget else abi.throwtargetpos
+
+                grenade = self.TossGrenade(unit, startpos, targetpos, unit.CalculateIgnoreOwnerCollisionGroup())
+
+                if grenade:
+                    abi.OnGrenadeThrowed(unit, grenade)
+                    grenade.SetVelocity(grenade.GetAbsVelocity(), Vector(0, 0, 0))
+                    grenade.SetTimer(2.5, 2.5 - grenade.FRAG_GRENADE_WARN_TIME)
+                    
+        aetable = dict(UnitCombine.aetable)
+        aetable[UnitCombine.COMBINE_AE_GREN_TOSS] = CombineHeavyThrowGrenade('grenade_frag', UnitCombine.COMBINE_GRENADE_THROW_SPEED)
             
 # Register unit
 class CombineSharedInfo(UnitInfo):

--- a/lambdawars/python/wars_game/units/combine_mine.py
+++ b/lambdawars/python/wars_game/units/combine_mine.py
@@ -1079,7 +1079,7 @@ class CombMineUpgrade(AbilityUpgradeValue):
         self.UpgradeCombineMines()
 
     def UpgradeCombineMines(self):
-        units = list(unitlistpertype[self.ownernumber]['combine_mine'])
+        units = (list(unitlistpertype[self.ownernumber].get('combine_mine', [])) + list(unitlistpertype[self.ownernumber].get('overrun_combine_mine', [])))
         for unit in units:
             unit.Cloak()
 

--- a/lambdawars/python/wars_game/units/headcrab.py
+++ b/lambdawars/python/wars_game/units/headcrab.py
@@ -333,6 +333,11 @@ class UnitBaseHeadcrab(BaseClass):
                 if enemy and unit.controllerplayer is None:
                     if unit.committedtojump:
                         unit.JumpAttack(False, unit.veccommittedjumppos)
+                    elif getattr(enemy, 'hd_jump_target_worldcenter', False):
+                        # Intended for entities where EyePosition() is unsuitable
+                        # (e.g. synthfactory, mortarsynth, teleporter,
+                        # control points, barricades, mountableturrets).
+                        unit.JumpAttack(False, enemy.WorldSpaceCenter())
                     else:
                         # Jump at my enemy's eyes.
                         unit.JumpAttack(False, enemy.EyePosition())

--- a/lambdawars/python/wars_game/units/rebel.py
+++ b/lambdawars/python/wars_game/units/rebel.py
@@ -1052,6 +1052,7 @@ class MedicSMG1Upgrade(AbilityUpgrade):
 
         self.UpgradeMedicInfo(RebelMedicInfo, RebelMedicSmg1Info)
         self.UpgradeMedicInfo(DestroyHQRebelMedicInfo, DestroyHQRebelMedicSmg1Info)
+        self.UpgradeMedicInfo(OverrunRebelMedicInfo, OverrunRebelMedicSmg1Info)
 
     def UpgradeMedicInfo(self, info, successor_info):
         # Ensure buildings producing this unit now produce the medic with smg1
@@ -1256,6 +1257,13 @@ class OverrunRebelMedicInfo(RebelMedicInfo):
         -1: 'garrison',
     }
 
+class OverrunRebelMedicSmg1Info(RebelMedicSmg1Info):
+    name = 'overrun_unit_rebel_medic_smg1'
+    costs = [('kills', 5)]
+    hidden = True
+    buildtime = 0
+    tier = 0
+    techrequirements = ['or_tier2_research']
 	
 class OverrunRebelTauInfo(RebelTauInfo):
 	name = 'overrun_unit_rebel_tau'


### PR DESCRIPTION
Added two Overrun fixes:

- Existing `overrun_combine_mine` units now correctly receive the `cloak` upgrade.
- Added `overrun_unit_rebel_medic_smg1` and updated `medic_smg1_upgrade` so existing Overrun Rebel Medics are properly upgraded from the pistol version to the SMG1 version.