### PR TITLE
Fix Combine Heavy throw grenade

### DIFF
--- a/lambdawars/python/wars_game/units/combine.py
+++ b/lambdawars/python/wars_game/units/combine.py
@@ -82,7 +82,8 @@ class UnitCombine(BaseClass):
                     self.SetGrenadeClass(abi.grenadeclsname)
 
                 startpos = Vector()
-                unit.GetAttachment("lefthand", startpos)
+                if not unit.GetAttachment("lefthand", startpos):
+                    unit.GetAttachment("anim_attachment_RH", startpos)
 
                 targetpos = abi.throwtarget.GetAbsOrigin() if abi.throwtarget else abi.throwtargetpos
 


### PR DESCRIPTION
Added attachment lookup for `CombineThrowGrenade`.

This fixes Combine Heavy grenades spawning from the unit's WorldSpaceCenter instead of the correct attachment.