### PR TITLE
Fix Techrequirements Rebel Medic SMG1

### DIFF
--- a/lambdawars/python/wars_game/units/rebel.py
+++ b/lambdawars/python/wars_game/units/rebel.py
@@ -649,7 +649,6 @@ class RebelMedicSmg1Info(RebelMedicInfo):
     weapons = ['weapon_smg1']
     displayname = '#RebMedicSmg1_Name'
     description = '#RebMedicSmg1_Description'
-    techrequirements = []
 
 
 class DestroyHQRebelMedicInfo(RebelMedicInfo):


### PR DESCRIPTION
The SMG1 Rebel Medic variant was missing the same tech requirements as the base Rebel Medic, allowing it to become available without the required building.

This change restores the correct tech requirements by matching the base unit configuration.