### PR TITLE
Fix HeadCrab Jump Attack

### DIFF
--- a/lambdawars/python/wars_game/units/headcrab.py
+++ b/lambdawars/python/wars_game/units/headcrab.py
@@ -333,6 +333,8 @@ class UnitBaseHeadcrab(BaseClass):
                 if enemy and unit.controllerplayer is None:
                     if unit.committedtojump:
                         unit.JumpAttack(False, unit.veccommittedjumppos)
+                    elif getattr(enemy, 'hd_jump_target_worldcenter', False):
+                        unit.JumpAttack(False, enemy.WorldSpaceCenter())
                     else:
                         # Jump at my enemy's eyes.
                         unit.JumpAttack(False, enemy.EyePosition())


### PR DESCRIPTION
This change adds support for a special entity flag (`hd_jump_target_worldcenter`) that allows Headcrabs to use `WorldSpaceCenter()` instead of `EyePosition()` when selecting a jump target.

This fixes cases where certain low-profile entities are difficult or impossible for Headcrabs to hit because the default target position is too low or unavailable.

P.S. This flag is not enabled on any entities by default. It is intended to be assigned only to specific entities that require this behavior (for example: Teleporters, Control Points, Barricades, Mountable Turrets, etc.).