### PR TITLE
Fix Base Zombie Attack

### DIFF
--- a/lambdawars/python/wars_game/units/basezombie.py
+++ b/lambdawars/python/wars_game/units/basezombie.py
@@ -96,8 +96,8 @@ class UnitBaseZombie(BaseClass):
         #
         vecMins = self.WorldAlignMins()
         vecMaxs = self.WorldAlignMaxs()
-        vecMins.z = vecMins.x
-        vecMaxs.z = vecMaxs.x
+        vecMins.z = -24
+        vecMaxs.z = 24
 
         '''
         pHurt = None


### PR DESCRIPTION
This change adjusts the zombie melee attack bounds to improve hit detection.

It fixes cases where zombies were unable to reliably hit small units (such as Headcrabs and Manhacks) and targets standing on elevation changes or small ledges.