### PR TITLE
Overrun Rebel Medic SMG1

### DIFF
--- a/lambdawars/python/wars_game/units/rebel.py
+++ b/lambdawars/python/wars_game/units/rebel.py
@@ -1063,6 +1063,7 @@ class MedicSMG1Upgrade(AbilityUpgrade):
 
         self.UpgradeMedicInfo(RebelMedicInfo, RebelMedicSmg1Info)
         self.UpgradeMedicInfo(DestroyHQRebelMedicInfo, DestroyHQRebelMedicSmg1Info)
+        self.UpgradeMedicInfo(OverrunRebelMedicInfo, OverrunRebelMedicSmg1Info)
 
     def UpgradeMedicInfo(self, info, successor_info):
         # Ensure buildings producing this unit now produce the medic with smg1
@@ -1268,6 +1269,13 @@ class OverrunRebelMedicInfo(RebelMedicInfo):
         -1: 'garrison',
     }
 
+class OverrunRebelMedicSmg1Info(RebelMedicSmg1Info):
+    name = 'overrun_unit_rebel_medic_smg1'
+    costs = [('kills', 5)]
+    hidden = True
+    buildtime = 0
+    tier = 0
+    techrequirements = ['or_tier2_research']
 
 class OverrunRebelTauInfo(RebelTauInfo):
     name = 'overrun_unit_rebel_tau'


### PR DESCRIPTION
Added the new `OverrunRebelMedicSmg1` class and updated `medic_smg1_upgrade` to support Overrun Rebel Medics.

Previously, the upgrade had no effect on the Overrun medic because an SMG1 variant was missing.