### PR TITLE
Fix cloak upgrade for Overrun Combine Mine

### DIFF
--- a/lambdawars/python/wars_game/units/combine_mine.py
+++ b/lambdawars/python/wars_game/units/combine_mine.py
@@ -1079,7 +1079,7 @@ class CombMineUpgrade(AbilityUpgradeValue):
         self.UpgradeCombineMines()
 
     def UpgradeCombineMines(self):
-        units = list(unitlistpertype[self.ownernumber]['combine_mine'])
+        units = (list(unitlistpertype[self.ownernumber].get('combine_mine', [])) + list(unitlistpertype[self.ownernumber].get('overrun_combine_mine', [])))
         for unit in units:
             unit.Cloak()
 


### PR DESCRIPTION
This PR updates `combinemine_upgrade` to support Overrun Combine Mines.

The upgrade now applies the cloaking effect to both `combine_mine` and `overrun_combine_mine`, ensuring that all existing mines owned by the player are updated correctly after the upgrade is researched.