### PR TITLE
Added helper function for health upgrades

### DIFF
--- a/lambdawars/python/core/units/base.py
+++ b/lambdawars/python/core/units/base.py
@@ -315,7 +315,42 @@ class UnitBaseShared(object):
         
         # Reset precache register for PrecacheUnitType
         cls.precacheregister = set()
-            
+    
+    def GetHealthUpgradeBonus(self):
+        total = 0
+
+        for upgrade in getattr(self.unitinfo, 'hpupgrades', []):
+            if isinstance(upgrade, tuple):
+                upname, value = upgrade
+            else:
+                upname = upgrade
+                value = None
+
+            technode = GetTechNode(upname, self.GetOwnerNumber())
+            if not technode or not technode.techenabled:
+                continue
+
+            if value is None:
+                total += int(technode.upgradevalue)
+            else:
+                total += int(value)
+
+        return total
+        
+    def ApplyHealthUpgrades(self):
+        total = self.GetHealthUpgradeBonus()
+        previous = getattr(self, "_hp_bonus_applied", 0)
+
+        delta = total - previous
+
+        if not delta:
+            return
+
+        self.maxhealth += delta
+        self.health = min(max(self.health + delta, 1), self.maxhealth)
+
+        self._hp_bonus_applied = total
+    
     def Spawn(self):
         """ Called when the unit is spawned into the world.
         
@@ -329,6 +364,9 @@ class UnitBaseShared(object):
             if self.health == 0:
                 self.health = unitinfo.health 
             self.maxhealth = self.health
+            
+            self.ApplyHealthUpgrades()
+            
             self.energy = unitinfo.unitenergy_initial if unitinfo.unitenergy_initial != -1 else unitinfo.unitenergy
             # UpgradeFields may modify maxenergy, so prefer that over this. TODO: improvement desirable. Not very clear.
             if self.maxenergy == 0:

--- a/lambdawars/python/wars_game/units/combine.py
+++ b/lambdawars/python/wars_game/units/combine.py
@@ -258,8 +258,6 @@ class UnitCombine(BaseClass):
 class UnitCombineSniper(UnitCombine):
     canshootmove = False
     insteadyposition = BooleanField(value=False, networked=True)
-    maxhealth = UpgradeField(abilityname='combine_hp_upgrade', cppimplemented=True)
-    health = UpgradeField(abilityname='combine_hp_upgrade', cppimplemented=True)
     
     def OnInCoverChanged(self):
         super().OnInCoverChanged()
@@ -341,8 +339,18 @@ class CombineHPUpgrade(AbilityUpgradeValue):
     description = '#CombineHPUpgrade_Description'
     buildtime = 90.0
     costs = [[('requisition', 30), ('power', 30)], [('kills', 50)]]
-    upgradevalue = 240
+    upgradevalue = 40
     image_name = 'vgui/combine/abilities/combine_hp_upgrade'
+    
+    def OnUpgraded(self):
+        super().OnUpgraded()
+
+        ownernumber = self.ownernumber
+        from core.units.info import unitlist
+        for unit in unitlist[ownernumber]:
+            if not unit.IsAlive():
+                continue
+            unit.ApplyHealthUpgrades()
 
 class ArmyCombine_Tier3(AbilityUpgradeValue):
     name = 'armycombine_tier_3'
@@ -363,8 +371,6 @@ class UnitCombineGrenadeUpgradeShared(UnitCombine):
         self.UpdateAbilities()
         
     grenadeUnlocked = BooleanField(value=False, networked=True, clientchangecallback='OnGrenadeUnlockedChanged')
-    maxhealth = UpgradeField(abilityname='combine_hp_upgrade', cppimplemented=True)
-    health = UpgradeField(abilityname='combine_hp_upgrade', cppimplemented=True)
     buildtime = UpgradeField(abilityname='armycombine_tier_3', cppimplemented=True) #TODO: 'buildtime' doesn't work with UpgradeField?
 
 class CombineInfo(CombineSharedInfo):
@@ -381,6 +387,7 @@ class CombineInfo(CombineSharedInfo):
     maxspeed = 216.0
     viewdistance = 768
     attributes = ['medium']
+    hpupgrades = ['combine_hp_upgrade']
     sound_select = 'unit_combine_select'
     sound_move = 'unit_combine_move'
     sound_attack = 'unit_combine_attack'
@@ -572,6 +579,7 @@ class CombineSniperInfo(CombineSharedInfo):
     unitenergy_initial = 30
     #techrequirements = ['combine_sniper_unlock']
     attributes = ['medium']
+    hpupgrades = ['combine_hp_upgrade']
     sound_select = 'unit_combine_select'
     sound_move = 'unit_combine_move'
     sound_attack = 'unit_combine_attack'

--- a/lambdawars/python/wars_game/units/combine.py
+++ b/lambdawars/python/wars_game/units/combine.py
@@ -579,7 +579,6 @@ class CombineSniperInfo(CombineSharedInfo):
     unitenergy_initial = 30
     #techrequirements = ['combine_sniper_unlock']
     attributes = ['medium']
-    hpupgrades = ['combine_hp_upgrade']
     sound_select = 'unit_combine_select'
     sound_move = 'unit_combine_move'
     sound_attack = 'unit_combine_attack'

--- a/lambdawars/python/wars_game/units/rebel.py
+++ b/lambdawars/python/wars_game/units/rebel.py
@@ -223,8 +223,6 @@ class MissionUnitRebelEngineer(UnitRebelEngineer):
 class UnitRebelMedic(UnitRebel):
     energyregenrate = UpgradeField(value=1.0, abilityname='medic_regenerate_upgrade')
     maxenergy = UpgradeField(abilityname='medic_maxenergy_upgrade', cppimplemented=True)
-    maxhealth = UpgradeField(abilityname='rebel_hp_upgrade', cppimplemented=True)
-    health = UpgradeField(abilityname='rebel_hp_upgrade', cppimplemented=True)
 
 
 class RebelShared(UnitInfo):
@@ -431,9 +429,7 @@ class UnitRebelGrenadeUpgradeShared(UnitCitizen):
         if self.lasttakedamage and self.health > 0 and dmginfo.GetDamage() > 0:
             self.EmitSound('unit_rebel_hurt')
         return super().OnTakeDamage(dmginfo)
-
-    maxhealth = UpgradeField(abilityname='rebel_hp_upgrade', cppimplemented=True)
-    health = UpgradeField(abilityname='rebel_hp_upgrade', cppimplemented=True)
+        
     grenadeUnlocked = BooleanField(value=False, networked=True, clientchangecallback='OnGrenadeUnlockedChanged')
 
 
@@ -450,6 +446,7 @@ class RebelInfo(RebelShared):
     image_name = 'vgui/rebels/units/unit_rebel'
     weapons = ['weapon_smg1']
     attributes = ['medium']
+    hpupgrades = ['rebel_hp_upgrade']
     techrequirements = ['build_reb_munitiondepot']
     # tier = 2
     abilities = {
@@ -586,6 +583,7 @@ class RebelTauInfo(RebelInfo):
     }
     sensedistance = 1152.0
     attributes = ['heavy']
+    hpupgrades = []
     image_name = 'vgui/rebels/units/unit_rebel_tau'
     infest_zombietype = ''
 
@@ -617,6 +615,7 @@ class RebelHeavyInfo(RebelInfo):
     }
     sensedistance = 1024.0
     attributes = ['heavy']
+    hpupgrades = []
     image_name = 'vgui/rebels/units/unit_rebel_heavy'
     infest_zombietype = ''
 
@@ -641,6 +640,7 @@ class RebelMedicInfo(RebelShared):
     techrequirements = ['build_reb_triagecenter']
     modellist = GenerateModelList('MEDIC')
     attributes = ['medium']
+    hpupgrades = ['rebel_hp_upgrade']
     abilities = {
         0: 'heal',
         7: 'mountturret',
@@ -1014,9 +1014,18 @@ class RebelHPUpgrade(AbilityUpgradeValue):
     description = '#RebHpUpgrade_Description'
     buildtime = 90.0
     costs = [[('requisition', 30), ('scrap', 30)], [('kills', 50)]]
-    upgradevalue = 180
+    upgradevalue = 30
     image_name = 'vgui/rebels/abilities/rebel_hp_upgrade'
 
+    def OnUpgraded(self):
+        super().OnUpgraded()
+
+        ownernumber = self.ownernumber
+        from core.units.info import unitlist
+        for unit in unitlist[ownernumber]:
+            if not unit.IsAlive():
+                continue
+            unit.ApplyHealthUpgrades()
 
 # Medic upgrades
 class MedicHealRateUpgrade(AbilityUpgradeValue):

--- a/lambdawars/python/wars_game/units/rebel.py
+++ b/lambdawars/python/wars_game/units/rebel.py
@@ -640,7 +640,6 @@ class RebelMedicInfo(RebelShared):
     techrequirements = ['build_reb_triagecenter']
     modellist = GenerateModelList('MEDIC')
     attributes = ['medium']
-    hpupgrades = ['rebel_hp_upgrade']
     abilities = {
         0: 'heal',
         7: 'mountturret',


### PR DESCRIPTION
This PR adds a helper function for applying health upgrades to already existing units.

Previously, health upgrades relied on directly replacing health values, which could restore units to full health after researching an upgrade.

The new implementation calculates the health bonus delta and applies only the difference to both current and maximum health, preserving the unit's current health state while still granting the correct upgrade bonus.

The upgrade logic has also been refactored so that `OnUpgraded` simply iterates through the player's alive units and calls `ApplyHealthUpgrades()`, moving all health-related calculations into a dedicated helper function.