### PR TITLE
Fix Shield Generator visibility with Custom Can Be Seen

### DIFF
--- a/lambdawars/python/wars_game/buildings/combine/shieldgen.py
+++ b/lambdawars/python/wars_game/buildings/combine/shieldgen.py
@@ -357,20 +357,26 @@ class CombineShieldGeneratorPowered(BasePoweredBuilding, CombineShieldGenerator)
     def Spawn(self):
         super().Spawn()
 
-        self.SetCanBeSeen(False)
+        self.SetUseCustomCanBeSeenCheck(False)
     if isserver:
         def OnPoweredChanged(self):
             BasePoweredBuilding.OnPoweredChanged(self)
             if not self.powered:
                 self.DestroyAllLinks()
-                self.SetCanBeSeen(True)
+                self.SetUseCustomCanBeSeenCheck(False)
             else:
                 self.LinkToNearest()
-                self.SetCanBeSeen(False)
+                self.SetUseCustomCanBeSeenCheck(True)
                 
         def CreateLink(self, othergen):
             if self.powered:
                 super().CreateLink(othergen)
+    
+        def CustomCanBeSeen(self, unit=None):
+            if unit: 
+                if relationships[(self.GetOwnerNumber(), unit.GetOwnerNumber())] != D_LI:
+                    return False
+            return True
             
     autoconstruct = False
     buildtarget = Vector(0, -210, 0)


### PR DESCRIPTION
- Shield Generators can now be attacked by their owner, allowing them to be removed in DestroyHQ where the `Kill Selected Units` command is unavailable. Stalkers now correctly detect Shield Generators with auto-cast repair instead of requiring a manual right-click.
- Allied players can now attack and repair Shield Generators.
- Units now correctly path toward Shield Generators when issued move commands.