### PR TITLE
Squad Wars unit Char Rebel Flamer fix

### DIFF
--- a/lambdawars/python/wars_game/units/rebel.py
+++ b/lambdawars/python/wars_game/units/rebel.py
@@ -1690,7 +1690,7 @@ class CharacterRebelSoldier(RebelInfo):
     rechargetime = 180.0
 
 
-class CharacterRebelFlamer(UnitRebel):
+class CharacterRebelFlamer(RebelFlamer):
     name = 'char_rebel_flamer'
     cls_name = 'char_rebel_flamer'  # so that flamer doesn't explode when shot in the back
     displayname = '#CharRebFlamer_Name'


### PR DESCRIPTION
Fix CharacterRebelFlamer inheriting from the wrong base class. This restores correct ability display for all characters in the SquadWars build_sw_beacon.